### PR TITLE
Add mobile/tablet breakpoints

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,3 +31,26 @@
 	width: 80%;
 	flex-grow: 1;
 }
+
+@media (max-width: 1200px) {
+	.App-main > .Navigation {
+		padding-left: 1rem;
+	}
+}
+
+@media (max-width: 800px) {
+	.App-main {
+		display: block;
+	}
+
+	.App-main > .Navigation {
+		height: auto;
+		width: 100vw;
+		margin: 0;
+		z-index: 1;
+	}
+
+	.App-main > :nth-child( 2 ) {
+		width: auto;
+	}
+}

--- a/src/Footer.css
+++ b/src/Footer.css
@@ -54,3 +54,16 @@
 	color: var( --hm-warm-grey );
 	opacity: 1;
 }
+
+@media (max-width: 800px) {
+	.Footer .wrapper {
+		flex-direction: column;
+		padding: 0 0.5em;
+	}
+
+	.Footer .wrapper > *,
+	.Footer .wrapper > *:first-child {
+		width: auto;
+		margin: 0.5em 0;
+	}
+}

--- a/src/Header.css
+++ b/src/Header.css
@@ -110,3 +110,41 @@
 	margin: 0 0 0 0.5em;
 	overflow: unset;
 }
+
+@media (max-width: 800px) {
+	.Header .Logo {
+		height: 2em;
+	}
+
+	.Header .wrapper {
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.Header .SiteSelector {
+		margin: 0.5em 0 1em;
+	}
+
+	.Header-nav {
+		align-self: stretch;
+	}
+
+	.Header-nav > ul {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.Header-nav > ul > li {
+		margin: 0.5em 0;
+	}
+
+	.Header input[type=search] {
+		margin-left: 0;
+		width: 100%;
+		font-size: 1.2em;
+	}
+
+	.Header input[type=search]:focus {
+		width: 100%;
+	}
+}

--- a/src/Main.css
+++ b/src/Main.css
@@ -17,3 +17,18 @@
 .Main > .Sidebar {
 	flex-grow: 1;
 }
+
+@media (max-width: 800px) {
+	.Main {
+		display: block;
+	}
+
+	.Main-content {
+		width: auto;
+		padding: 0 1em;
+	}
+
+	.Main > .Sidebar {
+		display: none;
+	}
+}

--- a/src/Navigation.css
+++ b/src/Navigation.css
@@ -14,3 +14,10 @@ body.admin-bar .Navigation {
 	top: 32px;
 	height: calc( 100vh - 32px );
 }
+
+@media (max-width: 800px) {
+	.Navigation {
+		position: static;
+		background: #fff;
+	}
+}

--- a/src/PageNavigation.css
+++ b/src/PageNavigation.css
@@ -22,3 +22,15 @@
 .PageNavigation-arrow {
 	margin: 0 0.5em;
 }
+
+@media (max-width: 800px) {
+	.PageNavigation {
+		flex-direction: column;
+	}
+
+	.PageNavigation > div {
+		border: none;
+		width: auto;
+		margin: 0 0 0.5em;
+	}
+}


### PR DESCRIPTION
* Adds a 800px breakpoint for mobile and below which switches to single column layout
* Adds a 1200px breakpoint just to ensure proper padding

In a future PR, I'll make the nav an expando instead so we don't waste important vertical space and force mobile users to scroll for a year. :)

![screen shot 2018-12-03 at 18 22 42](https://user-images.githubusercontent.com/21655/49393392-f9699980-f728-11e8-9ce8-d44737586f09.png)
