### PR TITLE
Force rebuild node-sass in build script to prevent build error

### DIFF
--- a/.build-script
+++ b/.build-script
@@ -9,5 +9,6 @@ export NVM_DIR="$HOME/.nvm"
 #install latest version of node
 nvm install 8
 
+npm rebuild node-sass --force
 npm install
 npm run build


### PR DESCRIPTION
When running the build locally it errored at the red-book build due to nvm version switching invalidating the existing node-sass binding. This makes the build run to completion. Tested with subsequent runs and appears to continue to work ok.