### PR TITLE
Remove PM Handbook Link from the Site Selector.

### DIFF
--- a/src/SiteSelector.js
+++ b/src/SiteSelector.js
@@ -24,12 +24,6 @@ export default function SiteSelector( props ) {
 				Read about how we work as a company.
 			</a>
 		</li>
-		<li>
-			<a href="https://pm.hmn.md/">
-				<span>Project Management Handbook</span>
-				Read how we manage projects.
-			</a>
-		</li>
 
 		{ user ?
 			<React.Fragment>


### PR DESCRIPTION
Per @jennybeaumont in https://github.com/humanmade/Engineering/issues/204, the current link to the PM Handbook from this site is not accurate and gives an incorrect impression of the company.